### PR TITLE
Fixed famous ammo bug

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -170,6 +170,7 @@ AddEventHandler('esx:addWeapon', function(weaponName, ammo)
   local weaponHash = GetHashKey(weaponName)
 
   GiveWeaponToPed(playerPed, weaponHash, ammo, false, false)
+  SetPedAmmo(playerPed, weaponHash, ammo) -- remove leftover ammo
 end)
 
 RegisterNetEvent('esx:removeWeapon')
@@ -178,6 +179,7 @@ AddEventHandler('esx:removeWeapon', function(weaponName)
   local weaponHash = GetHashKey(weaponName)
 
   RemoveWeaponFromPed(playerPed,  weaponHash)
+  SetPedAmmo(playerPed, weaponHash, 0) -- remove leftover ammo
 end)
 
 -- Commands
@@ -337,7 +339,6 @@ AddEventHandler('esx:pickupWeapon', function(weaponPickup, weaponName,ammo)
 
   local ped          = GetPlayerPed(-1)
   local playerPedPos = GetEntityCoords(ped, true)
-  print(ammo)
   CreateAmbientPickup(GetHashKey(weaponPickup), playerPedPos.x + 2.0, playerPedPos.y, playerPedPos.z + 0.5, 0, ammo, 1, false, true)
   
 end)


### PR DESCRIPTION
Fixed the famous ammo bug where if you remove a weapon from your inventory, it doesn't remove the ammo for it.
### Note
- also fixes the duplicating ammo from `esx_property`, or storing weapons in any way.