### PR TITLE
Update main.lua (Fix Issue #38)

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -542,7 +542,7 @@ AddEventHandler('esx:onPickup', function(id)
   if pickup.type == 'item_standard' then
 
     local item      = xPlayer.getInventoryItem(pickup.name)
-    local canTake   = (item.limit - item.count > 0) and (item.limit - item.count) or 0
+    local canTake   = ((item.limit == -1) and (pickup.count)) or ((item.limit - item.count > 0) and (item.limit - item.count)) or 0
     local total     = pickup.count < canTake and pickup.count or canTake
     local remaining = pickup.count - total
 


### PR DESCRIPTION
Fix [#38](https://github.com/ESX-Org/es_extended/issues/38), item pickup issue. 
If item.limit is defined as -1 in the database (unlimited), assign canTake to the pickup amount since there is no limit.