### PR TITLE
Resolved invalid number format

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -20,7 +20,7 @@ TriggerEvent('es:addGroupCommand', 'setjob', 'jobmaster', function(source, args,
 	if tonumber(args[1]) and args[2] and tonumber(args[3]) then
 		local xPlayer = ESX.GetPlayerFromId(args[1])
 		if xPlayer ~= nil then
-			xPlayer.setJob(args[2], args[3])
+			xPlayer.setJob(args[2], tonumber(args[3]))
 		else
 			TriggerClientEvent('chatMessage', source, "SYSTEM", {255, 0, 0}, "Player not online.")
 		end


### PR DESCRIPTION
Setting jobs on players causes grade check to return an error rather than the check itself.

`if PlayerData.job.grade >= 3 then` returns `Attempt to compare number with string`