### PR TITLE
Simplify string-uppercase helper method

### DIFF
--- a/locale.lua
+++ b/locale.lua
@@ -16,6 +16,6 @@ function _(str, ...)  -- Translate string
 
 end
 
-function _U(str, ...) -- Translate string first char uppercase
-  return tostring(_(str, ...):gsub("^%l", string.upper))
+function _U(str) -- Translate string first char uppercase
+  if type(str) == "string" then return string.gsub(str, ".", string.upper, 1) end
 end


### PR DESCRIPTION
Avoids conflicts with multiple, non-string params being passed in as varargs (such as a table) as they are currently unhandled.

This would ensure that only single strings are passed in, and only the very first character is set to be uppercase.

- However, because of it looking for the very first character, such strings as "1hello" would not be changed to "1Hello" - though, I can quickly fix this if the latter ("1Hello") would be intended.