### PR TITLE
Updated __resource.lua

### DIFF
--- a/__resource.lua
+++ b/__resource.lua
@@ -55,6 +55,7 @@ client_scripts {
 	'client/modules/scaleform.lua',
 	'client/modules/streaming.lua',
 
+	'shared/modules/math.lua',
 	'shared/functions.lua'
 }
 


### PR DESCRIPTION
Added math.lua to client side scripts.

Caused esx_tattooshop throwing errors, since math.lua was not loaded client side.