### PR TITLE
Fixed math.lua ESX.Math.Round()

### DIFF
--- a/common/modules/math.lua
+++ b/common/modules/math.lua
@@ -1,7 +1,11 @@
 ESX.Math = {}
 
 ESX.Math.Round = function(value, numDecimalPlaces)
-	return tonumber(string.format("%." .. (numDecimalPlaces or 0) .. "f", value))
+	if (numDecimalPlaces) then
+		return math.floor((value * 10^numDecimalPlaces) + 0.5) / (10^numDecimalPlaces)
+	else
+		return math.floor(value+0.5)
+	end
 end
 
 -- credit http://richard.warburton.it


### PR DESCRIPTION
Appropriate way to round a number by decimal. String.format output unexpected behavior with some systems.