### PR TITLE
Fix mislocated break in player accounts' loop

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -35,9 +35,8 @@ AddEventHandler('es:playerLoaded', function(source, _player)
 								money = accounts[j].money,
 								label = Config.AccountLabels[accounts[j].name]
 							})
+							break
 						end
-
-						break
 					end
 				end
 


### PR DESCRIPTION
When looping in user's accounts, the "break" was executed after the first loop no matter what.
It should break the loop only when the account has been found in database.