### PR TITLE
Updated OneSync comment

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -10,6 +10,6 @@ Config.DisableWantedLevel   = true
 Config.EnableHud            = true -- enable the default hud? Display current job and accounts (black, bank & cash)
 
 Config.PaycheckInterval     = 7 * 60000
-Config.MaxPlayers           = GetConvarInt('sv_maxclients', 32) -- set this value to 255 if you're running OneSync
+Config.MaxPlayers           = GetConvarInt('sv_maxclients', 32) -- set this value to 128 if you're running OneSync
 
 Config.EnableDebug          = false


### PR DESCRIPTION
sv_maxclients always need to be player slots (so 64 or 128), only loops need to be changed to 255 or 256 in some case.