### PR TITLE
Addition to addWeapon

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -166,9 +166,23 @@ RegisterNetEvent('esx:addWeapon')
 AddEventHandler('esx:addWeapon', function(weaponName, ammo)
 	local playerPed  = PlayerPedId()
 	local weaponHash = GetHashKey(weaponName)
-
-	GiveWeaponToPed(playerPed, weaponHash, ammo, false, false)
-	--AddAmmoToPed(playerPed, weaponHash, ammo) possibly not needed
+	local hasWeapon = HasPedGotWeapon(playerPed, weaponHash, false)
+	if ammo == nil and 
+		if not hasWeapon then
+			GiveWeaponToPed(playerPed, weaponHash, 0, false, false)
+		end
+	else
+		local pedAmmo = GetAmmoInPedWeapon(playerPed, weaponHash)
+		ammo = math.floor(pedAmmo + ammo)
+		if ammo > 250 then
+			ammo = 250
+		end
+		if hasWeapon then
+			AddAmmoToPed(playerPed, weaponHash, ammo)	
+		else
+			GiveWeaponToPed(playerPed, weaponHash, ammo, false, false)	
+		end
+	end
 end)
 
 RegisterNetEvent('esx:addWeaponComponent')


### PR DESCRIPTION
If the ammo parameter is not supplied then it will give the ped the weapon with zero ammo.

Else if the ammo parameter is supplied and the client already has the weapon it will only update the ammo.
else if the client doesn't have the weapon it'll give them that weapon with the correct ammo.