### PR TITLE
Loadout & confiscating fix (read desc)

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -406,10 +406,6 @@ Citizen.CreateThread(function()
 		local loadout        = {}
 		local loadoutChanged = false
 
-		if IsPedDeadOrDying(playerPed) then
-			isLoadoutLoaded = false
-		end
-
 		for k,v in ipairs(Config.Weapons) do
 			local weaponName = v.name
 			local weaponHash = GetHashKey(weaponName)


### PR DESCRIPTION
This issue have been a pain in the ass for most of the ESX users. Unfortunately no one have fixed it, but it's rather simple to do it. When removing this three lines of code, the players loadout will get saved every 5th second, and will fix the issue when people get their loadout back if they get revived. A huge exploit there you could dupe weapons. 