### PR TITLE
Added Cash support to /giveaccountmoney

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -74,7 +74,9 @@ TriggerEvent('es:addGroupCommand', 'giveaccountmoney', 'admin', function(source,
 		local amount = tonumber(args[3])
 
 		if amount then
-			if xPlayer.getAccount(account) then
+			if account == 'cash' then
+				xPlayer.addMoney(amount)
+			else if xPlayer.getAccount(account) then
 				xPlayer.addAccountMoney(account, amount)
 			else
 				TriggerClientEvent('esx:showNotification', source, _U('invalid_account'))


### PR DESCRIPTION
Just to have a easy way to give cash to a person i have added a check to see if account == cash, just to avoide having more commands.

Not sure if you want this doubt it, but think it would make sence, since the "cash" "wallet" is somewhat an account, and it makes it easyer to give cash in hand to a person if needed.