### PR TITLE
Pearlescent+WheelColor Fix

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -764,7 +764,9 @@ ESX.Game.SetVehicleProperties = function(vehicle, props)
 		if props.dirtLevel then SetVehicleDirtLevel(vehicle, props.dirtLevel + 0.0) end
 		if props.color1 then SetVehicleColours(vehicle, props.color1, colorSecondary) end
 		if props.color2 then SetVehicleColours(vehicle, props.color1 or colorPrimary, props.color2) end
-		if props.pearlescentColor then SetVehicleExtraColours(vehicle, props.pearlescentColor, wheelColor) end
+		if props.pearlescentColor then SetVehicleExtraColours(vehicle, props.pearlescentColor, wheelColor) 
+		pearlescentColor = props.pearlescentColor
+		end
 		if props.wheelColor then SetVehicleExtraColours(vehicle, pearlescentColor, props.wheelColor) end
 		if props.wheels then SetVehicleWheelType(vehicle, props.wheels) end
 		if props.windowTint then SetVehicleWindowTint(vehicle, props.windowTint) end


### PR DESCRIPTION
the way it was written when a vehicle spawn/setproperties it wasnt keeping pearlscentColor because of the second Native trigger right after for the wheelColor