### PR TITLE
Support table/list of groups when registering commands

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -138,7 +138,13 @@ ESX.RegisterCommand = function(name, group, cb, allowConsole, suggestion)
 		end
 	end, true)
 
-	ExecuteCommand(('add_ace group.%s command.%s allow'):format(group, name))
+	if type(group) == 'table' then
+		for _, groupName in ipairs(group) do
+			ExecuteCommand(('add_ace group.%s command.%s allow'):format(groupName, name))
+		end
+	else
+		ExecuteCommand(('add_ace group.%s command.%s allow'):format(group, name))
+	end
 end
 
 ESX.ClearTimeout = function(id)

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -139,8 +139,8 @@ ESX.RegisterCommand = function(name, group, cb, allowConsole, suggestion)
 	end, true)
 
 	if type(group) == 'table' then
-		for _, groupName in ipairs(group) do
-			ExecuteCommand(('add_ace group.%s command.%s allow'):format(groupName, name))
+		for k,v in ipairs(group) do
+			ExecuteCommand(('add_ace group.%s command.%s allow'):format(v, name))
 		end
 	else
 		ExecuteCommand(('add_ace group.%s command.%s allow'):format(group, name))


### PR DESCRIPTION
Since name parameter supports a list of aliases or w/e, why not do the same for groups?
Example use:
```lua
function CarCommand(...)
   ... -- actual code for command
end
ESX.RegisterCommand({"car", "vehicle", "veh"}, {"admin", "$900vip", "carman", "moderator", "admincar"}, CarCommand)
```
Someone wanted a way to register a command to multiple groups, since they probaly don't nest them or want them separated, here's an easy way without registering the command multiple times.