### PR TITLE
On player death, the isDead never set to false

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -81,6 +81,8 @@ RegisterNetEvent('esx:setMaxWeight')
 AddEventHandler('esx:setMaxWeight', function(newMaxWeight) ESX.PlayerData.maxWeight = newMaxWeight end)
 
 AddEventHandler('esx:onPlayerDeath', function() isDead = true end)
+RegisterNetEvent('esx_ambulancejob:revive')
+AddEventHandler('esx_ambulancejob:revive', function() isDead = false end)
 AddEventHandler('skinchanger:loadDefaultModel', function() isLoadoutLoaded = false end)
 
 AddEventHandler('skinchanger:modelLoaded', function()


### PR DESCRIPTION
When a player die and they got revived, on es_extended the 'isDead' var never set to false, so the player can't open the inventory if 'isDead' is true