### PR TITLE
Fix "ER_DATA_TOO_LONG" while updating character

### DIFF
--- a/es_extended.sql
+++ b/es_extended.sql
@@ -9,7 +9,7 @@ CREATE TABLE `users` (
 	`job` VARCHAR(20) NULL DEFAULT 'unemployed',
 	`job_grade` INT(11) NULL DEFAULT 0,
 	`loadout` LONGTEXT NULL DEFAULT NULL,
-	`position` VARCHAR(53) NULL DEFAULT '{"x":-269.4,"y":-955.3,"z":31.2,"heading":205.8}',
+	`position` VARCHAR(120) NULL DEFAULT '{"x":-269.4,"y":-955.3,"z":31.2,"heading":205.8}',
 
 	PRIMARY KEY (`identifier`)
 );


### PR DESCRIPTION
Hi, while playing I got the following error:
```
[ERROR] [MySQL] [es_extended] An error happens on MySQL for query "UPDATE users SET accounts = '{\"bank\":72200}', job = 'unemployed', job_grade = 0, `group` = 'user', loadout = '[]', position = '{\"y\":-336.5,\"x\":-495.09999999998,\"heading\":248.20000000002,\"z\":34.399999999994}', inventory = '[]' WHERE identifier = 'foo'": ER_DATA_TOO_LONG: Data too long for column 'position' at row 1
```

Considering that the position (`{\"y\":-336.5,\"x\":-495.09999999998,\"heading\":248.20000000002,\"z\":34.399999999994}`) here is 87 characters long, I've increased the max value of the `position` column to 120 chars.