### PR TITLE
Add the "item_name" as an argument when executing the use item callback

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -244,7 +244,7 @@ ESX.RegisterUsableItem = function(item, cb)
 end
 
 ESX.UseItem = function(source, item)
-	ESX.UsableItemsCallbacks[item](source)
+	ESX.UsableItemsCallbacks[item](source, item)
 end
 
 ESX.GetItemLabel = function(item)


### PR DESCRIPTION
This PR adds the `item` which is basically the `item_name` as an argument so the callback has some information about itself. This will allow for some more efficient callbacks and more.