### PR TITLE
Update es_extended for newer features

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -71,12 +71,17 @@ AddEventHandler('esx:playerLoaded', function(playerData)
 		TriggerEvent('playerSpawned') -- compatibility with old scripts, will be removed soon
 		TriggerEvent('esx:restoreLoadout')
 
-		Citizen.Wait(3000)
+		Citizen.Wait(4000)
 		ShutdownLoadingScreen()
+		ShutdownLoadingScreenNui()
 		FreezeEntityPosition(PlayerPedId(), false)
 		DoScreenFadeIn(10000)
 		StartServerSyncLoops()
 	end)
+
+	if Config.UseESXIdentity then
+		TriggerEvent('esx:loadingScreenOff')
+	end
 end)
 
 RegisterNetEvent('esx:setMaxWeight')
@@ -379,6 +384,16 @@ if Config.EnableHud then
 			end
 		end
 	end)
+
+	if Config.UseESXIdentity then
+		AddEventHandler('esx:loadingScreenOff', function()
+			ESX.UI.HUD.SetDisplay(1.0)
+		end)
+	else
+		AddEventHandler('esx:onPlayerSpawn', function()
+			ESX.UI.HUD.SetDisplay(1.0)
+		end)
+	end
 end
 
 function StartServerSyncLoops()

--- a/config.lua
+++ b/config.lua
@@ -14,17 +14,6 @@ Config.EnableHud            = true -- enable the default hud? Display current jo
 Config.MaxWeight            = 24   -- the max inventory weight without backpack
 Config.PaycheckInterval     = 7 * 60000 -- how often to recieve pay checks in milliseconds
 Config.EnableDebug          = false
+Config.UseESXIdentity       = false -- Enable support for ESX Identity features, and support for custom loading screens
 
-Config.IncompatibleResourcesToStop = {
-	['essentialmode'] = 'ES for short, the performance heavy RP framework no one uses - and source for the random unwanted ZAP ads you\'re seeing',
-	['es_admin2'] = 'Adminstration tool for the ancient ES framework that wont work with ESX',
-	['esplugin_mysql'] = 'MySQL "plugin" for the ancient ES framework that has a SQL injection vulnerability',
-	['es_ui'] = 'Money HUD for ES',
-	['spawnmanager'] = 'Default resource that takes care of spawning players, ESX does this already',
-	['mapmanager'] = 'Default resource that was required by spawnmanager, but neither are used',
-	['basic-gamemode'] = 'Resource that is solely for choosing the default game type',
-	['fivem'] = 'Resource that is solely for choosing the default game type',
-	['fivem-map-hipster'] = 'Default spawn locations for mapmanager',
-	['fivem-map-skater'] = 'Default spawn locations for mapmanager',
-	['baseevents'] = 'Default resource for handling death events, ESX does this already'
-}
+Config.IncompatibleResourcesToStop = {}

--- a/html/css/app.css
+++ b/html/css/app.css
@@ -13,6 +13,7 @@ html {
 }
 
 #hud {
+	opacity: 0.0;
 	position: absolute;
 	font-family: 'Pricedown';
 	font-size: 35px;


### PR DESCRIPTION
1) Increase Citizen.Wait(3000) to Citizen.Wait(4000) so that the loading screen will shut down at a unified time between local and remote hosted servers
2) Include ShutdownLoadingScreenNui() for custom loading screens
3) Add additional event for Config.UseESXIdentity called esx:loadingScreenOff for future requests that will prevent UI objects from showing before the loading screen is shut down
4) Added default opacity of 0.0 to UI so that the script can determine when to show the UI based on whether loading screen is open or not, and if pause menu is active or not
5) Removed list of resources to force stop as FiveM is against shutting these scripts down, and most don't agree with forcing scripts to stop