### PR TITLE
Re-add certain QoL code and loadingScreenOff event

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -125,14 +125,22 @@ AddEventHandler('esx:playerLoaded', function(playerData)
 		heading  = playerData.coords.heading,
 		model    = 'mp_m_freemode_01',
 		skipFade = false
-  }, function()
+	}, function()
 
 		TriggerServerEvent('esx:onPlayerSpawn')
 		TriggerEvent('esx:onPlayerSpawn')
-    TriggerEvent('esx:restoreLoadout')
+		TriggerEvent('esx:restoreLoadout')
 
-  end)
+		-- Bring back loading screen shutdown support, and wait for faster clients to not load too early. (ArkSeyonet)
+		Citizen.Wait(4000)
+		ShutdownLoadingScreen()
+		ShutdownLoadingScreenNui()
+		DoScreenFadeIn(5000)
 
+	end)
+
+	-- Add loading screen off event for when spawning is finished. (ArkSeyonet)
+	TriggerEvent('esx:loadingScreenOff')
 end)
 
 RegisterNetEvent('esx:setMaxWeight')

--- a/modules/hud/data/html/css/app.css
+++ b/modules/hud/data/html/css/app.css
@@ -17,6 +17,8 @@ img {
 }
 
 #hud {
+  /* Add default opacity: 0.0; (ArkSeyonet) */
+  opacity: 0.0;
   position: absolute;
   font-family: 'Pricedown';
   font-size: 3.57vh;

--- a/modules/voice/client/main.lua
+++ b/modules/voice/client/main.lua
@@ -3,10 +3,13 @@ local Input = ESX.Modules['input']
 
 self.Init()
 
-ESX.Loop('draw-voice-level',function ()
-	if NetworkIsPlayerTalking(PlayerId()) then
-		self.DrawLevel(41, 128, 185, 255)
-	else
-		self.DrawLevel(185, 185, 185, 255)
-  end
-end,0)
+-- Add loading screen off event handler to wait for loading screen to be off before showing Voice HUD (ArkSeyonet)
+AddEventHandler('esx:loadingScreenOff', function()
+	ESX.Loop('draw-voice-level',function ()
+		if NetworkIsPlayerTalking(PlayerId()) then
+			self.DrawLevel(41, 128, 185, 255)
+		else
+			self.DrawLevel(185, 185, 185, 255)
+		end
+	end,0)
+end)


### PR DESCRIPTION
- Fix indent on Smallo's addition for spawnmanager
- Add back wait during spawnmanager spawn to not load too early, and be able to shut down loading screen properly again if using custom loading screen.
- Add event for loadingScreenOff because onPlayerSpawn triggers before loading screen is shut down.
- Add event handler for loadingScreenOff for voice module so that voice HUD doesn't show before loading screen is shut down