### PR TITLE
Re-add QoL code and support for custom loading screens

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -125,13 +125,22 @@ AddEventHandler('esx:playerLoaded', function(playerData)
 		heading  = playerData.coords.heading,
 		model    = 'mp_m_freemode_01',
 		skipFade = false
-  }, function()
+	}, function()
 
 		TriggerServerEvent('esx:onPlayerSpawn')
 		TriggerEvent('esx:onPlayerSpawn')
-    TriggerEvent('esx:restoreLoadout')
+		TriggerEvent('esx:restoreLoadout')
 
-  end)
+		-- Re add wait so that player is loaded before loading screen shuts down, and support for custom loading screens
+		Citizen.Wait(4000)
+		ShutdownLoadingScreen()
+		ShutdownLoadingScreenNui()
+		
+	end)
+
+	-- Add loading screen off event for when spawning is finished. (ArkSeyonet)
+	Citizen.Wait(5000)
+	TriggerEvent('esx:loadingScreenOff')
 
 end)
 
@@ -499,6 +508,25 @@ end)
 
 -- Pause menu disables HUD display
 if Config.EnableHud then
+
+	-- Temp Fix For GTA Cash and Bank showing behind ESX HUD until more permanent solution is made? (ArkSeyonet)
+	Citizen.CreateThread(function()
+		while true do
+			Citizen.Wait(1)
+
+			-- Hide GTA Cash
+			HideHudComponentThisFrame(3)
+			-- Hide GTA Bank
+			HideHudComponentThisFrame(4)
+		
+		end
+	end)
+
+	-- Set ESX HUD display to 1.0 once loading screen is off (ArkSeyonet)
+	AddEventHandler('esx:loadingScreenOff', function()
+		ESX.UI.HUD.SetDisplay(1.0)
+	end)
+
 	Citizen.CreateThread(function()
 		while true do
 			Citizen.Wait(300)

--- a/modules/hud/data/html/css/app.css
+++ b/modules/hud/data/html/css/app.css
@@ -17,6 +17,7 @@ img {
 }
 
 #hud {
+  opacity: 0.0;
   position: absolute;
   font-family: 'Pricedown';
   font-size: 3.57vh;

--- a/modules/voice/client/main.lua
+++ b/modules/voice/client/main.lua
@@ -3,10 +3,13 @@ local Input = ESX.Modules['input']
 
 self.Init()
 
-ESX.Loop('draw-voice-level',function ()
-	if NetworkIsPlayerTalking(PlayerId()) then
-		self.DrawLevel(41, 128, 185, 255)
-	else
-		self.DrawLevel(185, 185, 185, 255)
-  end
-end,0)
+-- Add loading screen off event handler to wait for loading screen to be off before showing Voice HUD (ArkSeyonet)
+AddEventHandler('esx:loadingScreenOff', function()
+	ESX.Loop('draw-voice-level',function ()
+		if NetworkIsPlayerTalking(PlayerId()) then
+			self.DrawLevel(41, 128, 185, 255)
+		else
+			self.DrawLevel(185, 185, 185, 255)
+		end
+	end,0)
+end)


### PR DESCRIPTION
- Fix Indent For Smallo's code for spawnmanager
- Add wait so player model is loaded before loading screen shuts down
- Add support for shutting down custom loading screens automatically after wait to give time for player model to load
- Add loading screen off event to trigger HUD elements to display, so that they do not display while loading screen is still active
- Add event handler for voice for loading screen off