### PR TITLE
Automatically open skin menu after registering

### DIFF
--- a/modules/__core__/identity/client/module.lua
+++ b/modules/__core__/identity/client/module.lua
@@ -72,6 +72,7 @@ self.OpenMenu = function()
           self.Menu = nil
 
           utils.ui.showNotification(_U('identity_welcome', props.firstName, props.lastName))
+          emit('esx:skin:registered')
         else
           utils.ui.showNotification(_U('identity_fill_in'))
         end

--- a/modules/skin/client/events.lua
+++ b/modules/skin/client/events.lua
@@ -56,6 +56,10 @@ onServer('esx_skin:openSaveableMenu', function(submitCb, cancelCb)
 	self.OpenSaveableMenu(submitCb, cancelCb, nil)
 end)
 
+on('esx:skin:registered', function(submitCb, cancelCb)
+	self.OpenSaveableMenu(submitCb, cancelCb, nil)
+end)	
+
 onServer('esx_skin:openSaveableRestrictedMenu', function(submitCb, cancelCb, restrict)
 	self.OpenSaveableMenu(submitCb, cancelCb, restrict)
 end)


### PR DESCRIPTION
Incase GiZz wants this added.

Players can still use /skin afterwards to open the menu again. 