### PR TITLE
readme: no mysql support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ### Requirements:
 
-- An installed MariaDB server (MySQL not supported for now).
+- An installed MariaDB server (we will not support MySQL).
 - [Async script by ESX-Org](https://github.com/ESX-Org/async)
 - [Cron script by ESX-Org](https://github.com/ESX-Org/cron)
 - [SkinChanger script by ESX-Org](https://github.com/ESX-Org/skinchanger)


### PR DESCRIPTION
Ok so basically MySQL 8.0 support won't be made

First because it add this to the README

---------------

### A note about MySQL 8.0+
MySQL changed its authentication protocol since version 8.0. MySQL-async doesn't use this protocol, hence, in-order-to make your MySQL server compatible you'll have to force the use of the `mysql_native_password` mysql module :
* On Windows and Linux, find the `my.cnf` file (it's the MySQL server configuration file) and use this :
  ```conf
  [mysqld]
  default-authentication-plugin=mysql_native_password
  ```
* On Docker-Compose add this `command: --default-authentication-plugin=mysql_native_password`

_don't forget to reaload the service after configuration changing_

That is not finished. If you already have a MySQL user, you have to run these SQL statements:
```sql
ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY '{my_password}';
ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '{my_password}';
SELECT plugin FROM mysql.user WHERE User = 'root';
```
--------------------

And then because it's impossible to set default value on Text, Blob and Json fields